### PR TITLE
Focus on search bar on launch

### DIFF
--- a/app/src/main/java/org/mcxa/vortaro/MainActivity.kt
+++ b/app/src/main/java/org/mcxa/vortaro/MainActivity.kt
@@ -29,7 +29,8 @@ class MainActivity : AppCompatActivity() {
             adapter = WordAdapter()
             layoutManager = LinearLayoutManager(this@MainActivity)
         }
-
+        
+        search_text.requestFocus();
         search_text.addTextChangedListener(object: TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 


### PR DESCRIPTION
Sorry I'm not a programmer so sorry if this is a 'hacky' way to do things. I wanted to make it easier to use the app, every time I launched it I needed to tap the search bar (one extra step), instead of just going ahead and searching for a word.